### PR TITLE
feat: Add Auto Mode Room Size Preset — remembered Room Size target for Room Size/Efficient auto profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,11 +216,14 @@ The vent angle is set as a number entity (45° = nearly closed/upward, 90° = fu
 | Feature | Type | Config Key | Description |
 |---------|----|------------|-------------|
 | Auto Mode | select | `auto_mode` | Auto mode type — options vary by model (see below) **Not for Core200S** |
-| Auto Mode Room Size | number | `efficiency_room_size` | Target room area for efficient auto mode in m² **Not for Core200S / EverestAir** |
+| Auto Mode Room Size | number | `efficiency_room_size` | MCU-reported room area for efficient auto mode in m² — reflects device status **Not for Core200S / EverestAir** |
+| Auto Mode Room Size Preset | number | `auto_profile_room_size_input` | Remembered Room Size target, automatically sent when selecting Room Size/Efficient auto profile. Persists across reboots so Default/Quiet status resets don't wipe the target. **Not for Core200S / EverestAir** |
 | Efficiency Counter | sensor | `efficiency_counter` | Seconds remaining at high fan speed in efficient auto mode **Vital only** |
 | Auto Mode High Fan Time | text_sensor | `auto_mode_room_size_high_fan` | Time still running at high speed in efficient auto mode, human readable **Vital only** |
 
 Auto Mode configures the purifier's automatic behavior and is distinct from the active fan preset/mode. On models with fan Auto support, changing Auto Mode enters the fan's Auto preset; direct fan speed changes switch the fan preset to Manual.
+
+When Room Size/Efficient is selected, the purifier uses **Auto Mode Room Size Preset** (`auto_profile_room_size_input`) as the coverage target and sends it to the MCU automatically. The **Auto Mode Room Size** number (`efficiency_room_size`) still reflects what the MCU reports back in status payloads — Default and Quiet profiles report `0`, which is normal.
 
 Auto mode options per model:
 
@@ -253,6 +256,15 @@ Auto mode options per model:
 | Error | text_sensor | `error_message` | Device error status: "Ok" or "Sensor Error" **Not for Core200S** |
 
 ### Change Log - Levoit Component
+
+#### ESP Version: 1.5.0 - unreleased
+
+* Add `auto_profile_room_size_input` number: persisted Room Size target for Room Size/Efficient auto profile (@EdenNelson)
+  * Automatically sent to the MCU when Room Size/Efficient is selected — no manual "Apply" step needed
+  * Survives Default/Quiet status resets that report room size as `0`
+  * Restores saved target on reboot, clamped to model-specific min/max
+  * Model ranges: C300S 9–50 m², C400S 9–38 m², C600S 9–147 m², V100S 9–52 m², V200S 9–87 m²
+  * Sprout: Room Size/Efficient mode is protocol-inherited from Vital but unverified on hardware — `auto_profile_room_size_input` not included for Sprout
 
 #### ESP Version: 1.4.0 - 2026.06.14
 

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -392,6 +392,11 @@ namespace esphome
                     this->sendCommand(setFanModeAuto);
                 break;
 
+            case NumberType::AUTO_PROFILE_ROOM_SIZE_INPUT:
+                // Just save — the MCU command fires when Room Size/Efficient
+                // is selected via the Auto Mode select, not on every edit.
+                break;
+
             case NumberType::SLEEP_MODE_MIN:
             case NumberType::SLEEP_FAN_LEVEL:
             case NumberType::QUICK_CLEAN_MIN:
@@ -458,6 +463,14 @@ namespace esphome
                         sent_auto_profile = true;
                         break;
                     case 2:
+                        // Inject the remembered room size target so the command
+                        // builder sends the right value, not the last MCU-echoed one.
+                        {
+                            auto *input = this->get_number(NumberType::AUTO_PROFILE_ROOM_SIZE_INPUT);
+                            auto *eff   = this->get_number(NumberType::EFFICIENCY_ROOM_SIZE);
+                            if (input != nullptr && eff != nullptr && input->has_state())
+                                eff->publish_state(input->state);
+                        }
                         this->sendCommand(setAutoModeEfficient);
                         sent_auto_profile = true;
                         break;

--- a/components/levoit/number/__init__.py
+++ b/components/levoit/number/__init__.py
@@ -41,11 +41,18 @@ TYPE_MAP = {
     "aqi_scale": NumberType.AQI_SCALE,
     # EverestAir only below
     "vent_angle": NumberType.VENT_ANGLE,
+    # Remembered Room Size target for Room Size/Efficient auto profile
+    "auto_profile_room_size_input": NumberType.AUTO_PROFILE_ROOM_SIZE_INPUT,
 }
 
 # (min_value, max_value, step, extra_props)
 TYPE_RANGE = {
     "efficiency_room_size": (9.0, 296.0, 1.0, {
+        CONF_DEVICE_CLASS: "area",
+        CONF_UNIT_OF_MEASUREMENT: "m²",
+        CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_CONFIG,
+    }),
+    "auto_profile_room_size_input": (9.0, 296.0, 1.0, {
         CONF_DEVICE_CLASS: "area",
         CONF_UNIT_OF_MEASUREMENT: "m²",
         CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_CONFIG,

--- a/components/levoit/number/levoit_number.cpp
+++ b/components/levoit/number/levoit_number.cpp
@@ -2,6 +2,7 @@
 #include "../levoit.h"
 #include "esphome/core/log.h"
 #include "esphome/components/number/number_traits.h"
+#include <algorithm>
 
 namespace esphome
 {
@@ -17,6 +18,25 @@ namespace esphome
       switch (this->type_) {
         case NumberType::EFFICIENCY_ROOM_SIZE:
           this->traits.set_mode(number::NumberMode::NUMBER_MODE_SLIDER);
+          break;
+
+        case NumberType::AUTO_PROFILE_ROOM_SIZE_INPUT:
+          this->traits.set_mode(number::NumberMode::NUMBER_MODE_BOX);
+
+          pref_ = global_preferences->make_preference<float>(fnv1_hash("levoit_room_size_input"));
+          {
+            float saved;
+            if (pref_.load(&saved)) {
+              float clamped = std::max(this->traits.get_min_value(),
+                                       std::min(this->traits.get_max_value(), saved));
+              ESP_LOGI(TAG, "Restored auto profile room size input: %.0f m²", clamped);
+              this->publish_state(clamped);
+            } else {
+              ESP_LOGI(TAG, "No saved room size input, defaulting to %.0f m²",
+                       this->traits.get_min_value());
+              this->publish_state(this->traits.get_min_value());
+            }
+          }
           break;
 
         case NumberType::TIMER:
@@ -56,10 +76,14 @@ namespace esphome
       // Optimistic update for HA UI
       this->publish_state(state);
       
-      // Save to preferences if filter_lifetime_months
+      // Save to preferences if filter_lifetime_months or auto_profile_room_size_input
       if (this->type_ == NumberType::FILTER_LIFETIME_MONTHS) {
         pref_.save(&value);
         ESP_LOGD(TAG, "Saved filter lifetime: %.0f months", value);
+      }
+      if (this->type_ == NumberType::AUTO_PROFILE_ROOM_SIZE_INPUT) {
+        pref_.save(&value);
+        ESP_LOGD(TAG, "Saved auto profile room size input: %.0f m²", value);
       }
       
       if (!parent_)

--- a/components/levoit/types.h
+++ b/components/levoit/types.h
@@ -57,6 +57,7 @@ namespace esphome
             QUICK_CLEAN_FAN_LEVEL = 15, // Vital: quick clean fan level (TLV 0x1B)
             DAYTIME_FAN_LEVEL = 16,     // Vital: daytime fan level (TLV 0x23)
             VENT_ANGLE = 17,            // EverestAir: vent louver angle 45–90° (CMD 02 12 55, status TLV 0x14)
+            AUTO_PROFILE_ROOM_SIZE_INPUT = 18, // Persisted user Room Size target for Room Size/Efficient auto profile
         };
         // Note: indices 0-11 must stay stable (serialized to preferences)
         // NumberType aliases (flat namespace)
@@ -76,6 +77,7 @@ namespace esphome
         static constexpr NumberType QUICK_CLEAN_FAN_LEVEL = NumberType::QUICK_CLEAN_FAN_LEVEL;
         static constexpr NumberType DAYTIME_FAN_LEVEL = NumberType::DAYTIME_FAN_LEVEL;
         static constexpr NumberType VENT_ANGLE = NumberType::VENT_ANGLE;
+        static constexpr NumberType AUTO_PROFILE_ROOM_SIZE_INPUT = NumberType::AUTO_PROFILE_ROOM_SIZE_INPUT;
 
         enum class SensorType : uint8_t
         {

--- a/devices/levoit-core300s/common.yaml
+++ b/devices/levoit-core300s/common.yaml
@@ -70,6 +70,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitcore300
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 50
+  - platform: levoit
+    levoit: levoitcore300
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-core300s/levoit-core300s-builder-c3.yaml
+++ b/devices/levoit-core300s/levoit-core300s-builder-c3.yaml
@@ -94,6 +94,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitcore300
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 50
+  - platform: levoit
+    levoit: levoitcore300
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-core300s/levoit-core300s-builder-s3.yaml
+++ b/devices/levoit-core300s/levoit-core300s-builder-s3.yaml
@@ -94,6 +94,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitcore300
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 50
+  - platform: levoit
+    levoit: levoitcore300
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-core300s/levoit-core300s-builder.yaml
+++ b/devices/levoit-core300s/levoit-core300s-builder.yaml
@@ -91,6 +91,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitcore300
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 50
+  - platform: levoit
+    levoit: levoitcore300
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-core400s/common.yaml
+++ b/devices/levoit-core400s/common.yaml
@@ -64,6 +64,12 @@ number:
     max_value: 38
   - platform: levoit
     levoit: levoitcore400
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 38
+  - platform: levoit
+    levoit: levoitcore400
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-core400s/levoit-core400s-builder-c3.yaml
+++ b/devices/levoit-core400s/levoit-core400s-builder-c3.yaml
@@ -88,6 +88,12 @@ number:
     max_value: 38
   - platform: levoit
     levoit: levoitcore400
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 38
+  - platform: levoit
+    levoit: levoitcore400
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-core400s/levoit-core400s-builder-s3.yaml
+++ b/devices/levoit-core400s/levoit-core400s-builder-s3.yaml
@@ -88,6 +88,12 @@ number:
     max_value: 38
   - platform: levoit
     levoit: levoitcore400
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 38
+  - platform: levoit
+    levoit: levoitcore400
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-core400s/levoit-core400s-builder.yaml
+++ b/devices/levoit-core400s/levoit-core400s-builder.yaml
@@ -85,6 +85,12 @@ number:
     max_value: 38
   - platform: levoit
     levoit: levoitcore400
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 38
+  - platform: levoit
+    levoit: levoitcore400
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-core600s/common.yaml
+++ b/devices/levoit-core600s/common.yaml
@@ -66,6 +66,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitcore600
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 147
+  - platform: levoit
+    levoit: levoitcore600
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-core600s/levoit-core600s-builder-c3.yaml
+++ b/devices/levoit-core600s/levoit-core600s-builder-c3.yaml
@@ -90,6 +90,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitcore600
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 147
+  - platform: levoit
+    levoit: levoitcore600
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-core600s/levoit-core600s-builder-s3.yaml
+++ b/devices/levoit-core600s/levoit-core600s-builder-s3.yaml
@@ -90,6 +90,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitcore600
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 147
+  - platform: levoit
+    levoit: levoitcore600
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-core600s/levoit-core600s-builder-solo-1c.yaml
+++ b/devices/levoit-core600s/levoit-core600s-builder-solo-1c.yaml
@@ -86,6 +86,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitcore600
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 147
+  - platform: levoit
+    levoit: levoitcore600
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-core600s/levoit-core600s-builder.yaml
+++ b/devices/levoit-core600s/levoit-core600s-builder.yaml
@@ -89,6 +89,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitcore600
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 147
+  - platform: levoit
+    levoit: levoitcore600
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-vital100s/common.yaml
+++ b/devices/levoit-vital100s/common.yaml
@@ -66,6 +66,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitvital100
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 52
+  - platform: levoit
+    levoit: levoitvital100
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-vital100s/levoit-vital100s-builder-c3.yaml
+++ b/devices/levoit-vital100s/levoit-vital100s-builder-c3.yaml
@@ -90,6 +90,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitvital100
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 52
+  - platform: levoit
+    levoit: levoitvital100
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-vital100s/levoit-vital100s-builder-s3.yaml
+++ b/devices/levoit-vital100s/levoit-vital100s-builder-s3.yaml
@@ -90,6 +90,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitvital100
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 52
+  - platform: levoit
+    levoit: levoitvital100
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-vital100s/levoit-vital100s-builder.yaml
+++ b/devices/levoit-vital100s/levoit-vital100s-builder.yaml
@@ -93,6 +93,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitvital100
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 52
+  - platform: levoit
+    levoit: levoitvital100
     name: "Filter Months"
     type: filter_lifetime_months
 

--- a/devices/levoit-vital200s/common.yaml
+++ b/devices/levoit-vital200s/common.yaml
@@ -74,6 +74,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitvital200
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 87
+  - platform: levoit
+    levoit: levoitvital200
     name: "Filter Months"
     type: filter_lifetime_months
   - platform: levoit

--- a/devices/levoit-vital200s/levoit-vital200s-builder-c3.yaml
+++ b/devices/levoit-vital200s/levoit-vital200s-builder-c3.yaml
@@ -98,6 +98,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitvital200
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 87
+  - platform: levoit
+    levoit: levoitvital200
     name: "Filter Months"
     type: filter_lifetime_months
   - platform: levoit

--- a/devices/levoit-vital200s/levoit-vital200s-builder-s3.yaml
+++ b/devices/levoit-vital200s/levoit-vital200s-builder-s3.yaml
@@ -98,6 +98,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitvital200
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 87
+  - platform: levoit
+    levoit: levoitvital200
     name: "Filter Months"
     type: filter_lifetime_months
   - platform: levoit

--- a/devices/levoit-vital200s/levoit-vital200s-builder.yaml
+++ b/devices/levoit-vital200s/levoit-vital200s-builder.yaml
@@ -93,6 +93,12 @@ number:
     type: efficiency_room_size
   - platform: levoit
     levoit: levoitvital200
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
+    min_value: 9
+    max_value: 87
+  - platform: levoit
+    levoit: levoitvital200
     name: "Filter Months"
     type: filter_lifetime_months
   - platform: levoit


### PR DESCRIPTION
Closes #55

## Summary

Adds `auto_profile_room_size_input` (`Auto Mode Room Size Preset`) — a persisted number entity that stores the user's intended Room Size coverage target and automatically sends it to the MCU when selecting the Room Size/Efficient auto profile.

## Problem

The purifier MCU reports room size as `0` in Default and Quiet auto profile status payloads. Without a separate remembered target, the `Auto Mode Room Size` number is overwritten to `0` on every status push, forcing users to re-enter their target each time they switch back to Room Size/Efficient.

## Solution

- New `auto_profile_room_size_input` number (YAML key `type: auto_profile_room_size_input`, displayed as `Auto Mode Room Size Preset`)
- Renders as a **box** (not slider) — visually distinct from the MCU-reported `Auto Mode Room Size` slider
- Persisted via ESPHome preferences — survives reboots including hard power cycles
- Clamped to model-specific min/max on restore
- When Room Size/Efficient is selected via the Auto Mode select, the remembered value is automatically injected before the MCU command is sent
- Editing the box just saves — does not send a MCU command unless Room Size/Efficient is actively selected
- `Auto Mode Room Size` (existing) is untouched — still reflects MCU status echoes

## Per-model ranges

| Model | Min | Max |
|-------|-----|-----|
| C300S | 9 m² | 50 m² |
| C400S | 9 m² | 38 m² |
| C600S | 9 m² | 147 m² |
| V100S | 9 m² | 52 m² |
| V200S | 9 m² | 87 m² |

*Sprout: Room Size/Efficient mode is protocol-inherited from Vital but hardware-unverified — `auto_profile_room_size_input` not included.*

## Files changed

- `components/levoit/types.h` — new `AUTO_PROFILE_ROOM_SIZE_INPUT = 18`
- `components/levoit/number/__init__.py` — register type, range defaults, box mode
- `components/levoit/number/levoit_number.cpp` — setup (box mode, pref restore/save)
- `components/levoit/levoit.cpp` — save-only in `on_number_command`; inject preset in `on_select_command` before `setAutoModeEfficient`
- `devices/*/common.yaml` — 5 Core + Vital device configs updated (Sprout excluded)
- `devices/*/*builder*.yaml` — corresponding builder YAMLs updated
- `README.md` — Auto Mode table and change log updated

## Validation

- `git diff --check` — clean
- ESPHome 2026.5.1 local compile: Core400S, Core300S, Core600S, Vital100S, Vital200S, Core200S — all **SUCCESS**
- Sprout: pre-existing build environment issue on this machine (unrelated to this PR)
- Core400S live hardware test:
  - `Auto Mode Room Size Preset` box appears in HA (9–38 m²)
  - Editing the box saves correctly, fires no MCU command
  - Selecting Room Size auto profile sends the preset value to MCU (verified in logs)
  - Default/Quiet status echoes do not wipe the preset
  - Value survives hard power cycle (flash pulled mid-session)

## Disclosure

This PR was developed with human-in-the-loop review and GitHub Copilot / AI assistance. Hardware testing was performed on a Core400S. Vital100S/200S and Core300S/600S were compile-tested only — behavior relies on shared code paths that are identical to Core400S. Sprout is excluded pending hardware verification of Room Size/Efficient payload behavior.