### PR TITLE
Fix 27 compiler warnings in the Levoit component build

### DIFF
--- a/components/levoit/core_commands.cpp
+++ b/components/levoit/core_commands.cpp
@@ -129,7 +129,7 @@ namespace esphome
                     uint8_t size_high = (raw >> 8) & 0xFF;
 
                     ESP_LOGD(TAG_CORE_CMD, "setAutoModeEfficient: %.0f m² -> raw=%u (0x%02X 0x%02X)",
-                             m2, raw, size_low, size_high);
+                             m2, (unsigned)raw, size_low, size_high);
 
                     payload = {0x02, size_low, size_high};
                 }

--- a/components/levoit/core_status.cpp
+++ b/components/levoit/core_status.cpp
@@ -34,7 +34,7 @@ namespace esphome
       uint16_t initial_min = initial_sec / 60;
 
       ESP_LOGV(TAG_CORE, "Timer: remaining=%u sec (%u min), initial=%u sec (%u min)", 
-               remaining_sec, remaining_min, initial_sec, initial_min);
+               (unsigned)remaining_sec, remaining_min, (unsigned)initial_sec, initial_min);
 
       self->publish_number(NumberType::TIMER, initial_min);
       self->publish_text_sensor(TextSensorType::TIMER_DURATION_INITIAL, format_duration_minutes(initial_min));

--- a/components/levoit/decoder.cpp
+++ b/components/levoit/decoder.cpp
@@ -119,7 +119,7 @@ namespace esphome
         if (model == ModelType::CORE300S || model == ModelType::CORE400S)
         {
           // Core300S/400S status: ptype 0x30 0x40 or 0xB0 0x40
-          if (msg_type == 0x22 && (ptype0 == 0x30 && ptype1 == 0x40 || ptype0 == 0xB0 && ptype1 == 0x40))
+          if (msg_type == 0x22 && ((ptype0 == 0x30 && ptype1 == 0x40) || (ptype0 == 0xB0 && ptype1 == 0x40)))
           {
             decode_core_status(self, model, payload, payload_len);
           }

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -174,7 +174,7 @@ namespace esphome
                 const char *opt = fan_operating_mode_to_option_(value);
                 if (opt == nullptr)
                 {
-                    ESP_LOGW(TAG, "publish_select: invalid fan mode %u", value);
+                    ESP_LOGW(TAG, "publish_select: invalid fan mode %u", (unsigned)value);
                     return;
                 }
                 if (std::find(options.begin(), options.end(), opt) == options.end())
@@ -190,7 +190,7 @@ namespace esphome
             if (value >= options.size())
             {
                 ESP_LOGW(TAG, "publish_select: invalid index %u for type %d (options=%u)",
-                         value, (int)type, (unsigned)options.size());
+                         (unsigned)value, (int)type, (unsigned)options.size());
                 return;
             }
             const std::string &opt = options[value];
@@ -664,13 +664,13 @@ namespace esphome
             
             // Restore saved values or initialize to 0
             if (pref_used_cadr_.load(&used_cadr_)) {
-                ESP_LOGI(TAG, "Restored used_cadr: %u m³", used_cadr_);
+                ESP_LOGI(TAG, "Restored used_cadr: %u m³", (unsigned)used_cadr_);
             } else {
                 used_cadr_ = 0;
                 ESP_LOGI(TAG, "Initialized used_cadr to 0");
             }
             if (pref_total_runtime_.load(&total_runtime_)) {
-                ESP_LOGI(TAG, "Restored total_runtime: %u hours", total_runtime_);
+                ESP_LOGI(TAG, "Restored total_runtime: %u hours", (unsigned)total_runtime_);
             } else {
                 total_runtime_ = 0;
                 ESP_LOGI(TAG, "Initialized total_runtime to 0");

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -713,7 +713,8 @@ namespace esphome
                     uint32_t cadr_per_min = cadr_per_hour / 60;
                     used_cadr_ += cadr_per_min;
                     ESP_LOGD(TAG, "CADR tracked: +%u m³ (speed=%d, total=%u m³, runtime=%u min)", 
-                             cadr_per_min, speed, used_cadr_, total_runtime_);
+                             (unsigned)cadr_per_min, speed, (unsigned)used_cadr_,
+                             (unsigned)total_runtime_);
                     
                 }
                 

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -670,7 +670,7 @@ namespace esphome
                 ESP_LOGI(TAG, "Initialized used_cadr to 0");
             }
             if (pref_total_runtime_.load(&total_runtime_)) {
-                ESP_LOGI(TAG, "Restored total_runtime: %u hours", (unsigned)total_runtime_);
+                ESP_LOGI(TAG, "Restored total_runtime: %u min", (unsigned)total_runtime_);
             } else {
                 total_runtime_ = 0;
                 ESP_LOGI(TAG, "Initialized total_runtime to 0");

--- a/components/levoit/types.h
+++ b/components/levoit/types.h
@@ -228,7 +228,7 @@ namespace esphome
             // dedicated command for setSleepModeCustom
         } CommandType;
 
-        static const char *command_type_to_string(CommandType cmd)
+        inline const char *command_type_to_string(CommandType cmd)
         {
             static const char *const names[] = {
                 "ack",

--- a/components/levoit/vital_commands.cpp
+++ b/components/levoit/vital_commands.cpp
@@ -129,7 +129,7 @@ namespace esphome
           uint8_t size_high = (room_size >> 8) & 0xFF;
 
           ESP_LOGD(TAG_VITAL_CMD, "setAutoModeEfficient: %.0f m² -> raw=%u (0x%02X 0x%02X)",
-                   m2, room_size, size_low, size_high);
+                   m2, (unsigned)room_size, size_low, size_high);
 
           payload = {0x02, 0x01, 0x02, 0x03, 0x02, size_low, size_high};
         }


### PR DESCRIPTION
Closes #58.

A clean ESP-IDF build of the component prints 31 compiler warnings at
`logger: level: VERBOSE`. This clears 27 of them. There are no functional
changes: every edit is a linkage, format-string or parenthesisation fix, and
control flow, protocol bytes and entity definitions are unchanged. One log
message's unit label is also corrected, which changes that line's text — see
the last item below.

The motivation is signal rather than tidiness: at 31 routine warnings per
build, a genuinely new one is easy to miss.

### Changes

**`types.h` — `command_type_to_string` becomes `inline` instead of `static`
(15 warnings)**

Defined as `static` in a header, the function got a private copy in every
translation unit including `types.h`, and the 15 that do not call it each
reported it unused. `inline` gives the header definition the linkage it should
have had: one shared copy, no unused duplicates. It also shrinks the binary
slightly, because the three callers no longer carry a copy of the function and
its name table each.

**Four files — `(unsigned)` casts on 11 `uint32_t` log arguments
(11 warnings)**

`uint32_t` is `unsigned long` on xtensa, so `%u` mismatched its argument. The
values print correctly today since both types are 32 bits wide, so this is a
latent rather than live defect. Sites: `levoit.cpp:177`, `:192`, `:667`,
`:673`, `:715` (three arguments), `core_commands.cpp:131`,
`vital_commands.cpp:131`, and `core_status.cpp:36` (two arguments).

I used `(unsigned)` casts rather than `PRIu32` to match the style already used
throughout the component (`levoit.cpp:246`, `levoit.cpp:975`, `decoder.cpp:98`,
`core_commands.cpp:162`, `core_status.cpp:120`) and to avoid adding a
`<cinttypes>` include. `levoit.cpp:192` already cast its other two arguments
and had just missed this one.

Of the 11 format warnings, two are in `ESP_LOGV` calls and appear only at
`VERBOSE`; five are in `ESP_LOGD` calls and appear at `DEBUG` or above. A
`DEBUG` build therefore reports nine format warnings, while an `INFO` build
reports four.

**`decoder.cpp` — parenthesise the `&&` operands inside the `||`
(1 warning)**

Grouping is unchanged; `&&` already bound tighter than `||`. This only states
it explicitly, in the Core300S/400S status ptype test.

**`levoit.cpp` — `total_runtime` restore log says minutes, not hours
(no warning)**

Raised by the Copilot review on this PR. `total_runtime_` is incremented once
per minute by `track_cadr_usage()`, which runs on the 60000 ms gate in
`loop()`, so the value restored from preferences is in minutes. The restore
log claimed `hours`, overstating it 60x and disagreeing with the sibling line
at `levoit.cpp:715`, which already labels the same variable `min`. Corrected
to `min`. Log text only, on a line already in this diff, and the binary is
byte-identical after the change.

### Result

| | Before | After |
| --- | --- | --- |
| `-Wunused-function` | 15 | 0 |
| `-Wformat=` | 11 | 0 |
| `-Wparentheses` | 1 | 0 |
| `-Wswitch` | 4 | 4 |
| **Total** | **31** | **4** |

### Scope

This PR covers one remediation category: mechanical, behavior-preserving
corrections with an unambiguous fix. The four `-Wswitch` warnings at
`levoit.cpp:366` fall outside that category and are left for separate
treatment. Happy to pick them up in a follow-up.

### Validation

Agent-side, ESPHome 2026.8.2 / ESP-IDF 5.5.5, component sourced locally:

- `git diff --check` clean; full diff reviewed file by file.
- Local compile of a temporary local-source copy of
  `devices/levoit-core400s/levoit-core400s-builder.yaml` before and after the
  change. Both succeeded. Component warnings went 31 -> 4, the 4 remaining
  being the `-Wswitch` warnings noted above.
- Same local-source method, additional compiles: Vital200S at `DEBUG` and
  Sprout at `VERBOSE` both succeeded, each reporting the same 4 `-Wswitch`
  warnings and nothing else.
- Binary size at matching log level, before -> after: flash 928725 ->
  928333 bytes (392 smaller), RAM unchanged at 45196 bytes.
- Recompiled after the `total_runtime` label correction: still 4 `-Wswitch`
  warnings and nothing else, and flash and RAM byte-identical at 928333 /
  45196, so the figures above still describe the head of this branch.

Core400S hardware, ESP32-SOLO-1C, MCU status ptype `B040`:

- Clean full rebuild on the build server (all 18 Levoit translation units
  included in this configuration were recompiled, not an incremental build)
  reported only the 4 `-Wswitch` warnings. OTA succeeded; device booted and
  ran without a crash, reset or boot loop.
- Binary size on device at `INFO` level, upstream `main` -> this branch:
  872389 -> 871997 bytes, RAM 44996 both. The same 392-byte reduction seen
  locally, independently reproduced. Measured at `a3a3656`; the later label
  correction leaves the binary byte-identical, as noted above.
- Reflashed at `logger: level: VERBOSE` to exercise the format-corrected log
  calls. Six of the eleven cast arguments printed correct values:

  ```
  [D][levoit:715]: CADR tracked: +7 m3 (speed=4, total=195348 m3, runtime=106667 min)
  [D][levoit.core_cmd:131]: setAutoModeEfficient: 29 m2 -> raw=983 (0xD7 0x03)
  [V][levoit.core:036]: Timer: remaining=1795 sec (29 min), initial=1795 sec (29 min)
  ```

  `raw=983` is arithmetically correct (29 x 33.9066 = 983.3), the payload
  went out as `02 D7 03`, and the MCU status echo decoded back to 29 m2.
- `types.h`: the `inline` function is exercised on every command. Names
  resolve correctly, e.g. `Command triggered: setAutoModeEfficient` and
  `>>> Sending command setFanModeAuto`.
- `decoder.cpp`: the parenthesised condition is exercised continuously. All
  Core400S status frames arrive as ptype `B0 40`, which is the second
  parenthesised `&&` branch of the `||`, and they dispatch and decode normally.
- Behaviour spot-checked unchanged: Auto profile Room Size round trip,
  Manual/Auto transitions, fan speeds 1/3/4, `Current CADR` 442 / 331 / 110,
  timer set and countdown, filter percentage, preference writes.

Not covered by the hardware run, stated for completeness:

- `levoit.cpp:177` and `:192` are `ESP_LOGW` error paths that did not
  trigger, which is the correct outcome for a healthy device.
- `levoit.cpp:667` and `:673` fire in `setup()`, before the API log stream
  attaches, so the lines were not captured. They print `used_cadr_` and
  `total_runtime_`, the same two variables that render correctly at
  `levoit.cpp:715`, and the restored values were plainly correct at runtime.
- `vital_commands.cpp:131` is not reachable on a Core400S. It is the exact
  counterpart of the verified `core_commands.cpp:131` line. **No Vital
  hardware test was performed and none is claimed.**

### Disclosure

Human-in-the-loop: I reviewed this diff before submitting it, and I ran the
Core400S hardware test myself.

AI assistance was used. An agent-driven pass produced the diff, ran the
before/after local compiles, analysed the build and runtime logs, and drafted
this description; GitHub Copilot is also active in my editor. The change was
then reviewed by a second, independent model and harness before submission.

Every piece of validation described above was actually executed and its
output read. Nothing is claimed that was not run.
